### PR TITLE
Improve Trendyol image download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # codex-deneme
+
+## Trendyol Review Image Downloader
+
+This repository includes a Python script `download_trendyol_images.py` that downloads user photo review images from Trendyol product pages. The scraper opens the page with Playwright, enables the **Fotoğraflı Değerlendirme** filter and then opens the **Tümü** gallery to display every photo review. It repeatedly clicks the **Daha fazla göster** button while scrolling inside the gallery dialog until no new images load. During the process it listens for the page's own review API requests and parses their JSON payloads so every high‑resolution photo is saved without performing direct blocked requests.
+
+### Requirements
+- Python 3.9+
+- `playwright`
+- `playwright-stealth`
+- `requests`
+- (optional) `pyinstaller` for generating an executable
+
+Install dependencies and browsers:
+
+```bash
+pip install playwright playwright-stealth requests
+playwright install chromium
+```
+
+### Usage
+Run the script with a product URL:
+
+```bash
+python download_trendyol_images.py
+```
+
+The script saves images under `D:/Images` (on Windows). On Linux/macOS this path will be created as a directory literally named `D:` with a subfolder `Images`.
+If a network call fails or returns invalid JSON, the script ignores it so one bad response doesn't stop the entire download.
+
+### Building a Windows Executable
+You can turn the script into a standalone `.exe` using PyInstaller:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile download_trendyol_images.py
+```
+
+The resulting executable will appear under `dist/`.
+

--- a/download_trendyol_images.py
+++ b/download_trendyol_images.py
@@ -1,0 +1,126 @@
+import asyncio
+import os
+from typing import Set
+
+import requests
+from playwright.async_api import async_playwright, Page
+from playwright_stealth import stealth_async
+
+SAVE_DIR = "D:/Images"
+
+
+def _extract_from_result(result: dict, collected: Set[str]) -> None:
+    for item in result.get("imageSummary", []):
+        url = item.get("mediaFile", {}).get("url")
+        if url:
+            collected.add(url)
+    for review in result.get("productReviews", {}).get("content", []):
+        for media in review.get("mediaFiles", []):
+            url = media.get("url")
+            if url:
+                collected.add(url)
+
+
+async def fetch_review_images(url: str) -> None:
+    collected: Set[str] = set()
+
+    async def handle_response(resp):
+        if "product-reviews" not in resp.url:
+            return
+        if resp.status != 200:
+            print(f"Response {resp.url} -> {resp.status}")
+            return
+        try:
+            data = await resp.json()
+        except Exception:
+            print(f"Failed to parse JSON from {resp.url}")
+            return
+        _extract_from_result(data.get("result", {}), collected)
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True, args=["--ignore-certificate-errors"])
+        context = await browser.new_context(ignore_https_errors=True)
+        page: Page = await context.new_page()
+        await stealth_async(page)
+        page.on("response", handle_response)
+
+        await page.goto(url, timeout=60000)
+
+        try:
+            await page.get_by_text("Fotoğraflı Değerlendirme", exact=False).click()
+            await page.wait_for_timeout(2000)
+        except Exception:
+            pass
+
+        # Open the modal showing all photo reviews
+        try:
+            await page.get_by_text("Tümü", exact=False).click()
+            await page.wait_for_timeout(1500)
+        except Exception:
+            pass
+
+        modal = page.locator('div[role="dialog"] div[style*="overflow"]')
+
+        prev_count = 0
+        stagnant = 0
+        for _ in range(200):
+            btn = modal.locator("text=Daha fazla g\xF6ster")
+            if await btn.count() > 0:
+                try:
+                    await btn.first.click()
+                    await page.wait_for_timeout(1500)
+                except Exception:
+                    pass
+
+            try:
+                await modal.evaluate('(el) => el.scrollBy(0, el.scrollHeight)')
+            except Exception:
+                await page.mouse.wheel(0, 2000)
+            await page.wait_for_timeout(800)
+
+            try:
+                state = await page.evaluate("window.__REVIEW_APP_INITIAL_STATE__")
+                rating = state.get("ratingAndReviewResponse", {}).get("ratingAndReview", {})
+                _extract_from_result(rating, collected)
+            except Exception:
+                pass
+
+            if len(collected) == prev_count:
+                stagnant += 1
+            else:
+                prev_count = len(collected)
+                stagnant = 0
+
+            if await btn.count() == 0 and stagnant >= 3:
+                break
+
+        await page.wait_for_timeout(3000)
+        try:
+            state = await page.evaluate("window.__REVIEW_APP_INITIAL_STATE__")
+            rating = state.get("ratingAndReviewResponse", {}).get("ratingAndReview", {})
+            _extract_from_result(rating, collected)
+        except Exception:
+            pass
+
+        await browser.close()
+
+    os.makedirs(SAVE_DIR, exist_ok=True)
+    print(f"Attempting to download {len(collected)} images")
+    for i, img_url in enumerate(sorted(collected)):
+        try:
+            resp = requests.get(img_url, headers={"User-Agent": "Mozilla/5.0"})
+            ext = img_url.split(".")[-1].split("?")[0]
+            if len(ext) > 4:
+                ext = "jpg"
+            path = os.path.join(SAVE_DIR, f"image_{i}.{ext}")
+            with open(path, "wb") as f:
+                f.write(resp.content)
+            print(f"Saved {path} ({i + 1}/{len(collected)})")
+        except Exception as e:
+            print(f"Failed {img_url}: {e}")
+    print("Download completed")
+
+
+if __name__ == "__main__":
+    url = "https://www.trendyol.com/rissoli/rissoli-kadin-siyah-gold-yuzuk-detayli-gunluk-sandalet-p-927370327/yorumlar"
+    asyncio.run(fetch_review_images(url))


### PR DESCRIPTION
## Summary
- click the photo gallery **Tümü** button so all photo reviews are opened
- scroll the gallery modal and collect images as it loads
- document the new behavior in the README

## Testing
- `pip install requests playwright playwright-stealth`
- `playwright install chromium`
- `python download_trendyol_images.py` *(fails to fetch all images: only 28 downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ad3998c832da896c9e22dfa3e5a